### PR TITLE
fix: set default to `""` over `undefined`

### DIFF
--- a/src/scripts/functions/cad/envHandler.js
+++ b/src/scripts/functions/cad/envHandler.js
@@ -25,11 +25,11 @@ $(`#editEnv`).on('click', () => {
         $(`#env14`).prop('checked', false);
     }
 
-    $(`#env-DISCORD_BOT_TOKEN`).val(`${cad.env.DISCORD_BOT_TOKEN}`);
-    $(`#env-DISCORD_SERVER_ID`).val(`${cad.env.DISCORD_SERVER_ID}`);
-    $(`#env-DISCORD_CLIENT_ID`).val(`${cad.env.DISCORD_CLIENT_ID}`);
-    $(`#env-DISCORD_CLIENT_SECRET`).val(`${cad.env.DISCORD_CLIENT_SECRET}`);
-    $(`#env-STEAM_API_KEY`).val(`${cad.env.STEAM_API_KEY}`);
+    $(`#env-DISCORD_BOT_TOKEN`).val(`${cad.env.DISCORD_BOT_TOKEN || ""}`);
+    $(`#env-DISCORD_SERVER_ID`).val(`${cad.env.DISCORD_SERVER_ID || ""}`);
+    $(`#env-DISCORD_CLIENT_ID`).val(`${cad.env.DISCORD_CLIENT_ID || ""}`);
+    $(`#env-DISCORD_CLIENT_SECRET`).val(`${cad.env.DISCORD_CLIENT_SECRET || ""}`);
+    $(`#env-STEAM_API_KEY`).val(`${cad.env.STEAM_API_KEY || ""}`);
 
     $(`env`).show();
 });


### PR DESCRIPTION
Will fix these `undefined`'s:
![image](https://user-images.githubusercontent.com/53900565/180641106-901dd025-43fa-46a2-9b0d-3766c95c732f.png)
